### PR TITLE
Dedicated object for AT URI

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -21,6 +21,10 @@ let package = Package(
             name: "ATProtoXRPC",
             targets: ["ATProtoXRPC"]
         ),
+        .library(
+            name: "ATProtoCore",
+            targets: ["ATProtoCore"]
+        ),
     ],
     dependencies: [
         .package(url: "https://github.com/pointfreeco/swift-parsing.git", from: "0.13.0"),
@@ -31,12 +35,14 @@ let package = Package(
             dependencies: [
                 "ATProtoAPI",
                 "ATProtoXRPC",
+                "ATProtoCore",
             ]
         ),
         .target(
             name: "ATProtoAPI",
             dependencies: [
-                "ATProtoXRPC"
+                "ATProtoXRPC",
+                "ATProtoCore",
             ]
         ),
         .target(
@@ -52,6 +58,15 @@ let package = Package(
             name: "ATProtoXRPCTests",
             dependencies: [
                 "ATProtoXRPC"
+            ]
+        ),
+        .target(
+            name: "ATProtoCore"
+        ),
+        .testTarget(
+            name: "ATProtoCoreTests",
+            dependencies: [
+                "ATProtoCore"
             ]
         ),
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -28,6 +28,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/pointfreeco/swift-parsing.git", from: "0.13.0"),
+        .package(url: "https://github.com/apple/swift-collections.git", from: "1.0.0"),
     ],
     targets: [
         .target(
@@ -61,7 +62,10 @@ let package = Package(
             ]
         ),
         .target(
-            name: "ATProtoCore"
+            name: "ATProtoCore",
+            dependencies: [
+                .product(name: "OrderedCollections", package: "swift-collections"),
+            ]
         ),
         .testTarget(
             name: "ATProtoCoreTests",

--- a/README.md
+++ b/README.md
@@ -16,6 +16,9 @@ swift-atproto includes the following libraries.
 ### ATProtoXRPC
 `ATProtoXRPC` is a library that provides XRPC client and fundamental types for XRPC.
 
+### ATProtoCore
+`ATProtoCore` is a library that provides fundamental types for AT Protocol.
+
 ## Author
 - [andooown](https://github.com/andooown)
 

--- a/Sources/ATProto/Export.swift
+++ b/Sources/ATProto/Export.swift
@@ -1,2 +1,3 @@
 @_exported import ATProtoAPI
 @_exported import ATProtoXRPC
+@_exported import ATProtoCore

--- a/Sources/ATProtoCore/Entities/ATURI.swift
+++ b/Sources/ATProtoCore/Entities/ATURI.swift
@@ -1,0 +1,14 @@
+import Foundation
+
+// https://github.com/bluesky-social/atproto/blob/0533fab68ea32df4e00948ddfc2422c6f900223a/packages/syntax/src/aturi.ts
+
+public struct ATURI {
+    public var host: String
+    public var path: String?
+    public var query: String?
+    public var hash: String?
+
+    public init?(string: String) {
+        nil
+    }
+}

--- a/Sources/ATProtoCore/Entities/ATURI.swift
+++ b/Sources/ATProtoCore/Entities/ATURI.swift
@@ -19,6 +19,14 @@ public struct ATURI {
         self.query = match[Self.queryRef].map(String.init)
         self.hash = match[Self.hashRef].map(String.init)
     }
+
+    public var collection: String? {
+        path?.split(separator: "/").filter { !$0.isEmpty }.first.map(String.init)
+    }
+
+    public var rkey: String? {
+        path?.split(separator: "/").filter { !$0.isEmpty }.dropFirst().first.map(String.init)
+    }
 }
 
 private extension ATURI {

--- a/Sources/ATProtoCore/Entities/ATURI.swift
+++ b/Sources/ATProtoCore/Entities/ATURI.swift
@@ -4,7 +4,7 @@ import RegexBuilder
 
 // https://github.com/bluesky-social/atproto/blob/0533fab68ea32df4e00948ddfc2422c6f900223a/packages/syntax/src/aturi.ts
 
-public struct ATURI {
+public struct ATURI: Hashable {
     public var host: String
     public var path: String?
     public var query: OrderedDictionary<String, String?>

--- a/Sources/ATProtoCore/Entities/ATURI.swift
+++ b/Sources/ATProtoCore/Entities/ATURI.swift
@@ -62,6 +62,29 @@ public struct ATURI: Hashable {
     }
 }
 
+extension ATURI: Encodable {
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(self.toString())
+    }
+}
+
+extension ATURI: Decodable {
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let string = try container.decode(String.self)
+
+        guard let atURI = Self(string: string) else {
+            throw DecodingError.dataCorruptedError(
+                in: container,
+                debugDescription: "Invalid AT URI string: \(string)"
+            )
+        }
+
+        self = atURI
+    }
+}
+
 private extension ATURI {
     static let hostRef = Reference(Substring.self)
     static let pathRef = Reference(Substring?.self)

--- a/Sources/ATProtoCore/Entities/ATURI.swift
+++ b/Sources/ATProtoCore/Entities/ATURI.swift
@@ -1,4 +1,5 @@
 import Foundation
+import RegexBuilder
 
 // https://github.com/bluesky-social/atproto/blob/0533fab68ea32df4e00948ddfc2422c6f900223a/packages/syntax/src/aturi.ts
 
@@ -9,6 +10,96 @@ public struct ATURI {
     public var hash: String?
 
     public init?(string: String) {
-        nil
+        guard let match = try? Self.atURIRegex.wholeMatch(in: string) else {
+            return nil
+        }
+
+        self.host = String(match[Self.hostRef])
+        self.path = match[Self.pathRef].map(String.init)
+        self.query = match[Self.queryRef].map(String.init)
+        self.hash = match[Self.hashRef].map(String.init)
     }
+}
+
+private extension ATURI {
+    static let hostRef = Reference(Substring.self)
+    static let pathRef = Reference(Substring?.self)
+    static let queryRef = Reference(Substring?.self)
+    static let hashRef = Reference(Substring?.self)
+
+    static let atURIRegex = Regex {
+        Optionally {
+            Capture {
+                "at://"
+            }
+        }
+        // Host
+        Capture(as: hostRef) {
+            ChoiceOf {
+                Regex {
+                    "did:"
+                    OneOrMore {
+                        CharacterClass(
+                            .anyOf(":%-"),
+                            ("a"..."z"),
+                            ("0"..."9")
+                        )
+                    }
+                }
+                Regex {
+                    CharacterClass(
+                        ("a"..."z"),
+                        ("0"..."9")
+                    )
+                    ZeroOrMore {
+                        CharacterClass(
+                            .anyOf(".:-"),
+                            ("a"..."z"),
+                            ("0"..."9")
+                        )
+                    }
+                }
+            }
+        }
+        // Path
+        Optionally {
+            Capture(as: pathRef) {
+                Regex {
+                    "/"
+                    ZeroOrMore {
+                        CharacterClass(
+                            .anyOf("?#"),
+                            .whitespace
+                        )
+                        .inverted
+                    }
+                }
+            } transform: { $0 }
+        }
+        // Query
+        Optionally {
+            "?"
+            Capture(as: queryRef) {
+                Regex {
+                    OneOrMore {
+                        CharacterClass(
+                            .anyOf("#"),
+                            .whitespace
+                        )
+                        .inverted
+                    }
+                }
+            } transform: { $0 }
+        }
+        // Hash
+        Optionally {
+            Capture(as: hashRef) {
+                Regex {
+                    "#"
+                    OneOrMore(.whitespace.inverted)
+                }
+            } transform: { $0 }
+        }
+    }
+    .ignoresCase()
 }

--- a/Sources/ATProtoCore/Entities/ATURI.swift
+++ b/Sources/ATProtoCore/Entities/ATURI.swift
@@ -1,4 +1,5 @@
 import Foundation
+import OrderedCollections
 import RegexBuilder
 
 // https://github.com/bluesky-social/atproto/blob/0533fab68ea32df4e00948ddfc2422c6f900223a/packages/syntax/src/aturi.ts
@@ -6,9 +7,10 @@ import RegexBuilder
 public struct ATURI {
     public var host: String
     public var path: String?
-    public var query: String?
+    public var query: OrderedDictionary<String, String?>
     public var hash: String?
 
+    // TODO: Support relative URIs
     public init?(string: String) {
         guard let match = try? Self.atURIRegex.wholeMatch(in: string) else {
             return nil
@@ -16,16 +18,47 @@ public struct ATURI {
 
         self.host = String(match[Self.hostRef])
         self.path = match[Self.pathRef].map(String.init)
-        self.query = match[Self.queryRef].map(String.init)
+
+        let queryStr = match[Self.queryRef].map(String.init)
+        var query = OrderedDictionary<String, String?>()
+        for pair in queryStr?.split(separator: "&") ?? [] {
+            let parts = pair.split(separator: "=")
+            if parts.count == 1 {
+                query[String(parts[0])] = nil
+            } else {
+                query[String(parts[0])] = String(parts[1])
+            }
+        }
+        self.query = query
+
         self.hash = match[Self.hashRef].map(String.init)
     }
 
     public var collection: String? {
-        path?.split(separator: "/").filter { !$0.isEmpty }.first.map(String.init)
+        self.path?.split(separator: "/").filter { !$0.isEmpty }.first.map(String.init)
     }
 
     public var rkey: String? {
-        path?.split(separator: "/").filter { !$0.isEmpty }.dropFirst().first.map(String.init)
+        self.path?.split(separator: "/").filter { !$0.isEmpty }.dropFirst().first.map(String.init)
+    }
+
+    public func toString() -> String {
+        var path = self.path ?? "/"
+        if !path.hasPrefix("/") {
+            path = "/\(path)"
+        }
+
+        var qs = self.query.map { $0.key + ($0.value.map { "=\($0)" } ?? "") }.joined(separator: "&")
+        if !qs.isEmpty && !qs.hasPrefix("?")  {
+            qs = "?\(qs)"
+        }
+
+        var hash = self.hash ?? ""
+        if !hash.isEmpty && !hash.hasPrefix("#")   {
+            hash = "#\(hash)"
+        }
+
+        return "at://\(self.host)\(path)\(qs)\(hash)"
     }
 }
 

--- a/Sources/ATProtoXRPC/Entities/Indirect.swift
+++ b/Sources/ATProtoXRPC/Entities/Indirect.swift
@@ -44,7 +44,6 @@ extension Indirect: Encodable where T: Encodable {
                 try x.encode(to: encoder)
             }
         }
-
     }
 }
 
@@ -74,33 +73,6 @@ extension Indirect: Decodable where T: Decodable {
             self = .wrapped(try T(from: decoder))
         }
     }
-
-    private static func decodeURL(decoder: Decoder) throws -> URL {
-        let value = try String(from: decoder)
-        guard let url = URL(string: value) else {
-            throw DecodingError.dataCorrupted(
-                DecodingError.Context(
-                    codingPath: decoder.codingPath,
-                    debugDescription: "Invalid URL string."
-                )
-            )
-        }
-
-        return url
-    }
-
-    //    private static func decodeDate(decoder: Decoder) throws -> Date {
-    //        let value = try String(from: decoder)
-    //
-    //        let formatter = DateFormatter()
-    //        formatter.locale = Locale(identifier: "en_US_POSIX")
-    //        formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSSZZZZZ"
-    //        guard let url = URL(string: value) else {
-    //            throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: decoder.codingPath, debugDescription: "Invalid URL string."))
-    //        }
-    //
-    //        return url
-    //    }
 }
 
 extension Indirect: Equatable where T: Equatable {}

--- a/Tests/ATProtoCoreTests/Entities/ATURITests.swift
+++ b/Tests/ATProtoCoreTests/Entities/ATURITests.swift
@@ -1,0 +1,287 @@
+import XCTest
+
+@testable import ATProtoCore
+
+final class ATURITests: XCTestCase {
+    // https://github.com/bluesky-social/atproto/blob/0533fab68ea32df4e00948ddfc2422c6f900223a/packages/syntax/tests/aturi.test.ts#L4
+    func testInit() throws {
+        let cases: [(String, String, String?, String?, String?, UInt)] = [
+            ("foo.com", "foo.com", nil, nil, nil, #line),
+            ("at://foo.com", "foo.com", nil, nil, nil, #line),
+            ("at://foo.com/", "foo.com", "/", nil, nil, #line),
+            ("at://foo.com/foo", "foo.com", "/foo", nil, nil, #line),
+            ("at://foo.com/foo/", "foo.com", "/foo/", nil, nil, #line),
+            ("at://foo.com/foo/bar", "foo.com", "/foo/bar", nil, nil, #line),
+            ("at://foo.com?foo=bar", "foo.com", nil, "foo=bar", nil, #line),
+            ("at://foo.com?foo=bar&baz=buux", "foo.com", nil, "foo=bar&baz=buux", nil, #line),
+            ("at://foo.com/?foo=bar", "foo.com", "/", "foo=bar", nil, #line),
+            ("at://foo.com/foo?foo=bar", "foo.com", "/foo", "foo=bar", nil, #line),
+            ("at://foo.com/foo/?foo=bar", "foo.com", "/foo/", "foo=bar", nil, #line),
+            ("at://foo.com#hash", "foo.com", nil, nil, "#hash", #line),
+            ("at://foo.com/#hash", "foo.com", "/", nil, "#hash", #line),
+            ("at://foo.com/foo#hash", "foo.com", "/foo", nil, "#hash", #line),
+            ("at://foo.com/foo/#hash", "foo.com", "/foo/", nil, "#hash", #line),
+            ("at://foo.com?foo=bar#hash", "foo.com", nil, "foo=bar", "#hash", #line),
+            (
+                "did:example:EiAnKD8-jfdd0MDcZUjAbRgaThBrMxPTFOxcnfJhI7Ukaw",
+                "did:example:EiAnKD8-jfdd0MDcZUjAbRgaThBrMxPTFOxcnfJhI7Ukaw",
+                nil,
+                nil,
+                nil,
+                #line
+            ),
+            (
+                "at://did:example:EiAnKD8-jfdd0MDcZUjAbRgaThBrMxPTFOxcnfJhI7Ukaw",
+                "did:example:EiAnKD8-jfdd0MDcZUjAbRgaThBrMxPTFOxcnfJhI7Ukaw",
+                nil,
+                nil,
+                nil,
+                #line
+            ),
+            (
+                "at://did:example:EiAnKD8-jfdd0MDcZUjAbRgaThBrMxPTFOxcnfJhI7Ukaw/",
+                "did:example:EiAnKD8-jfdd0MDcZUjAbRgaThBrMxPTFOxcnfJhI7Ukaw",
+                "/",
+                nil,
+                nil,
+                #line
+            ),
+            (
+                "at://did:example:EiAnKD8-jfdd0MDcZUjAbRgaThBrMxPTFOxcnfJhI7Ukaw/foo",
+                "did:example:EiAnKD8-jfdd0MDcZUjAbRgaThBrMxPTFOxcnfJhI7Ukaw",
+                "/foo",
+                nil,
+                nil, 
+                #line
+            ),
+            (
+                "at://did:example:EiAnKD8-jfdd0MDcZUjAbRgaThBrMxPTFOxcnfJhI7Ukaw/foo/",
+                "did:example:EiAnKD8-jfdd0MDcZUjAbRgaThBrMxPTFOxcnfJhI7Ukaw",
+                "/foo/",
+                nil,
+                nil, 
+                #line
+            ),
+            (
+                "at://did:example:EiAnKD8-jfdd0MDcZUjAbRgaThBrMxPTFOxcnfJhI7Ukaw/foo/bar",
+                "did:example:EiAnKD8-jfdd0MDcZUjAbRgaThBrMxPTFOxcnfJhI7Ukaw",
+                "/foo/bar",
+                nil,
+                nil, 
+                #line
+            ),
+            (
+                "at://did:example:EiAnKD8-jfdd0MDcZUjAbRgaThBrMxPTFOxcnfJhI7Ukaw?foo=bar",
+                "did:example:EiAnKD8-jfdd0MDcZUjAbRgaThBrMxPTFOxcnfJhI7Ukaw",
+                nil,
+                "foo=bar",
+                nil, 
+                #line
+            ),
+            (
+                "at://did:example:EiAnKD8-jfdd0MDcZUjAbRgaThBrMxPTFOxcnfJhI7Ukaw?foo=bar&baz=buux",
+                "did:example:EiAnKD8-jfdd0MDcZUjAbRgaThBrMxPTFOxcnfJhI7Ukaw",
+                nil,
+                "foo=bar&baz=buux",
+                nil, 
+                #line
+            ),
+            (
+                "at://did:example:EiAnKD8-jfdd0MDcZUjAbRgaThBrMxPTFOxcnfJhI7Ukaw/?foo=bar",
+                "did:example:EiAnKD8-jfdd0MDcZUjAbRgaThBrMxPTFOxcnfJhI7Ukaw",
+                "/",
+                "foo=bar",
+                nil, 
+                #line
+            ),
+            (
+                "at://did:example:EiAnKD8-jfdd0MDcZUjAbRgaThBrMxPTFOxcnfJhI7Ukaw/foo?foo=bar",
+                "did:example:EiAnKD8-jfdd0MDcZUjAbRgaThBrMxPTFOxcnfJhI7Ukaw",
+                "/foo",
+                "foo=bar",
+                nil, 
+                #line
+            ),
+            (
+                "at://did:example:EiAnKD8-jfdd0MDcZUjAbRgaThBrMxPTFOxcnfJhI7Ukaw/foo/?foo=bar",
+                "did:example:EiAnKD8-jfdd0MDcZUjAbRgaThBrMxPTFOxcnfJhI7Ukaw",
+                "/foo/",
+                "foo=bar",
+                nil, 
+                #line
+            ),
+            (
+                "at://did:example:EiAnKD8-jfdd0MDcZUjAbRgaThBrMxPTFOxcnfJhI7Ukaw#hash",
+                "did:example:EiAnKD8-jfdd0MDcZUjAbRgaThBrMxPTFOxcnfJhI7Ukaw",
+                nil,
+                nil,
+                "#hash", 
+                #line
+            ),
+            (
+                "at://did:example:EiAnKD8-jfdd0MDcZUjAbRgaThBrMxPTFOxcnfJhI7Ukaw/#hash",
+                "did:example:EiAnKD8-jfdd0MDcZUjAbRgaThBrMxPTFOxcnfJhI7Ukaw",
+                "/",
+                nil,
+                "#hash", 
+                #line
+            ),
+            (
+                "at://did:example:EiAnKD8-jfdd0MDcZUjAbRgaThBrMxPTFOxcnfJhI7Ukaw/foo#hash",
+                "did:example:EiAnKD8-jfdd0MDcZUjAbRgaThBrMxPTFOxcnfJhI7Ukaw",
+                "/foo",
+                nil,
+                "#hash", 
+                #line
+            ),
+            (
+                "at://did:example:EiAnKD8-jfdd0MDcZUjAbRgaThBrMxPTFOxcnfJhI7Ukaw/foo/#hash",
+                "did:example:EiAnKD8-jfdd0MDcZUjAbRgaThBrMxPTFOxcnfJhI7Ukaw",
+                "/foo/",
+                nil,
+                "#hash", 
+                #line
+            ),
+            (
+                "at://did:example:EiAnKD8-jfdd0MDcZUjAbRgaThBrMxPTFOxcnfJhI7Ukaw?foo=bar#hash",
+                "did:example:EiAnKD8-jfdd0MDcZUjAbRgaThBrMxPTFOxcnfJhI7Ukaw",
+                nil,
+                "foo=bar",
+                "#hash", 
+                #line
+            ),
+
+            ("did:web:localhost%3A1234", "did:web:localhost%3A1234", nil, nil, nil, #line),
+            ("at://did:web:localhost%3A1234", "did:web:localhost%3A1234", nil, nil, nil, #line),
+            (
+                "at://did:web:localhost%3A1234/",
+                "did:web:localhost%3A1234",
+                "/",
+                nil,
+                nil, 
+                #line
+            ),
+            (
+                "at://did:web:localhost%3A1234/foo",
+                "did:web:localhost%3A1234",
+                "/foo",
+                nil,
+                nil, 
+                #line
+            ),
+            (
+                "at://did:web:localhost%3A1234/foo/",
+                "did:web:localhost%3A1234",
+                "/foo/",
+                nil,
+                nil, 
+                #line
+            ),
+            (
+                "at://did:web:localhost%3A1234/foo/bar",
+                "did:web:localhost%3A1234",
+                "/foo/bar",
+                nil,
+                nil, 
+                #line
+            ),
+            (
+                "at://did:web:localhost%3A1234?foo=bar",
+                "did:web:localhost%3A1234",
+                nil,
+                "foo=bar",
+                nil, 
+                #line
+            ),
+            (
+                "at://did:web:localhost%3A1234?foo=bar&baz=buux",
+                "did:web:localhost%3A1234",
+                nil,
+                "foo=bar&baz=buux",
+                nil, 
+                #line
+            ),
+            (
+                "at://did:web:localhost%3A1234/?foo=bar",
+                "did:web:localhost%3A1234",
+                "/",
+                "foo=bar",
+                nil, 
+                #line
+            ),
+            (
+                "at://did:web:localhost%3A1234/foo?foo=bar",
+                "did:web:localhost%3A1234",
+                "/foo",
+                "foo=bar",
+                nil, 
+                #line
+            ),
+            (
+                "at://did:web:localhost%3A1234/foo/?foo=bar",
+                "did:web:localhost%3A1234",
+                "/foo/",
+                "foo=bar",
+                nil, 
+                #line
+            ),
+            (
+                "at://did:web:localhost%3A1234#hash",
+                "did:web:localhost%3A1234",
+                nil,
+                nil,
+                "#hash", 
+                #line
+            ),
+            (
+                "at://did:web:localhost%3A1234/#hash",
+                "did:web:localhost%3A1234",
+                "/",
+                nil,
+                "#hash", 
+                #line
+            ),
+            (
+                "at://did:web:localhost%3A1234/foo#hash",
+                "did:web:localhost%3A1234",
+                "/foo",
+                nil,
+                "#hash", 
+                #line
+            ),
+            (
+                "at://did:web:localhost%3A1234/foo/#hash",
+                "did:web:localhost%3A1234",
+                "/foo/",
+                nil,
+                "#hash", 
+                #line
+            ),
+            (
+                "at://did:web:localhost%3A1234?foo=bar#hash",
+                "did:web:localhost%3A1234",
+                nil,
+                "foo=bar",
+                "#hash", 
+                #line
+            ),
+            (
+                "at://4513echo.bsky.social/app.bsky.feed.post/3jsrpdyf6ss23",
+                "4513echo.bsky.social",
+                "/app.bsky.feed.post/3jsrpdyf6ss23",
+                nil,
+                nil, 
+                #line
+            ),
+        ]
+
+        for (input, host, path, query, hash, line) in cases {
+            let uri = try XCTUnwrap(ATURI(string: input), line: line)
+
+            XCTAssertEqual(uri.host, host, line: line)
+            XCTAssertEqual(uri.path, path, line: line)
+            XCTAssertEqual(uri.query, query, line: line)
+            XCTAssertEqual(uri.hash, hash, line: line)
+        }
+    }
+}

--- a/Tests/ATProtoCoreTests/Entities/ATURITests.swift
+++ b/Tests/ATProtoCoreTests/Entities/ATURITests.swift
@@ -1,3 +1,4 @@
+import OrderedCollections
 import XCTest
 
 @testable import ATProtoCore
@@ -5,28 +6,28 @@ import XCTest
 final class ATURITests: XCTestCase {
     // https://github.com/bluesky-social/atproto/blob/0533fab68ea32df4e00948ddfc2422c6f900223a/packages/syntax/tests/aturi.test.ts#L4
     func testParsing() throws {
-        let cases: [(String, String, String?, String?, String?, UInt)] = [
-            ("foo.com", "foo.com", nil, nil, nil, #line),
-            ("at://foo.com", "foo.com", nil, nil, nil, #line),
-            ("at://foo.com/", "foo.com", "/", nil, nil, #line),
-            ("at://foo.com/foo", "foo.com", "/foo", nil, nil, #line),
-            ("at://foo.com/foo/", "foo.com", "/foo/", nil, nil, #line),
-            ("at://foo.com/foo/bar", "foo.com", "/foo/bar", nil, nil, #line),
-            ("at://foo.com?foo=bar", "foo.com", nil, "foo=bar", nil, #line),
-            ("at://foo.com?foo=bar&baz=buux", "foo.com", nil, "foo=bar&baz=buux", nil, #line),
-            ("at://foo.com/?foo=bar", "foo.com", "/", "foo=bar", nil, #line),
-            ("at://foo.com/foo?foo=bar", "foo.com", "/foo", "foo=bar", nil, #line),
-            ("at://foo.com/foo/?foo=bar", "foo.com", "/foo/", "foo=bar", nil, #line),
-            ("at://foo.com#hash", "foo.com", nil, nil, "#hash", #line),
-            ("at://foo.com/#hash", "foo.com", "/", nil, "#hash", #line),
-            ("at://foo.com/foo#hash", "foo.com", "/foo", nil, "#hash", #line),
-            ("at://foo.com/foo/#hash", "foo.com", "/foo/", nil, "#hash", #line),
-            ("at://foo.com?foo=bar#hash", "foo.com", nil, "foo=bar", "#hash", #line),
+        let cases: [(String, String, String?, OrderedDictionary<String, String?>, String?, UInt)] = [
+            ("foo.com", "foo.com", nil, [:], nil, #line),
+            ("at://foo.com", "foo.com", nil, [:], nil, #line),
+            ("at://foo.com/", "foo.com", "/", [:], nil, #line),
+            ("at://foo.com/foo", "foo.com", "/foo", [:], nil, #line),
+            ("at://foo.com/foo/", "foo.com", "/foo/", [:], nil, #line),
+            ("at://foo.com/foo/bar", "foo.com", "/foo/bar", [:], nil, #line),
+            ("at://foo.com?foo=bar", "foo.com", nil, ["foo": "bar"], nil, #line),
+            ("at://foo.com?foo=bar&baz=buux", "foo.com", nil, ["foo": "bar", "baz": "buux"], nil, #line),
+            ("at://foo.com/?foo=bar", "foo.com", "/", ["foo": "bar"], nil, #line),
+            ("at://foo.com/foo?foo=bar", "foo.com", "/foo", ["foo": "bar"], nil, #line),
+            ("at://foo.com/foo/?foo=bar", "foo.com", "/foo/", ["foo": "bar"], nil, #line),
+            ("at://foo.com#hash", "foo.com", nil, [:], "#hash", #line),
+            ("at://foo.com/#hash", "foo.com", "/", [:], "#hash", #line),
+            ("at://foo.com/foo#hash", "foo.com", "/foo", [:], "#hash", #line),
+            ("at://foo.com/foo/#hash", "foo.com", "/foo/", [:], "#hash", #line),
+            ("at://foo.com?foo=bar#hash", "foo.com", nil, ["foo": "bar"], "#hash", #line),
             (
                 "did:example:EiAnKD8-jfdd0MDcZUjAbRgaThBrMxPTFOxcnfJhI7Ukaw",
                 "did:example:EiAnKD8-jfdd0MDcZUjAbRgaThBrMxPTFOxcnfJhI7Ukaw",
                 nil,
-                nil,
+                [:],
                 nil,
                 #line
             ),
@@ -34,7 +35,7 @@ final class ATURITests: XCTestCase {
                 "at://did:example:EiAnKD8-jfdd0MDcZUjAbRgaThBrMxPTFOxcnfJhI7Ukaw",
                 "did:example:EiAnKD8-jfdd0MDcZUjAbRgaThBrMxPTFOxcnfJhI7Ukaw",
                 nil,
-                nil,
+                [:],
                 nil,
                 #line
             ),
@@ -42,7 +43,7 @@ final class ATURITests: XCTestCase {
                 "at://did:example:EiAnKD8-jfdd0MDcZUjAbRgaThBrMxPTFOxcnfJhI7Ukaw/",
                 "did:example:EiAnKD8-jfdd0MDcZUjAbRgaThBrMxPTFOxcnfJhI7Ukaw",
                 "/",
-                nil,
+                [:],
                 nil,
                 #line
             ),
@@ -50,31 +51,31 @@ final class ATURITests: XCTestCase {
                 "at://did:example:EiAnKD8-jfdd0MDcZUjAbRgaThBrMxPTFOxcnfJhI7Ukaw/foo",
                 "did:example:EiAnKD8-jfdd0MDcZUjAbRgaThBrMxPTFOxcnfJhI7Ukaw",
                 "/foo",
+                [:],
                 nil,
-                nil, 
                 #line
             ),
             (
                 "at://did:example:EiAnKD8-jfdd0MDcZUjAbRgaThBrMxPTFOxcnfJhI7Ukaw/foo/",
                 "did:example:EiAnKD8-jfdd0MDcZUjAbRgaThBrMxPTFOxcnfJhI7Ukaw",
                 "/foo/",
+                [:],
                 nil,
-                nil, 
                 #line
             ),
             (
                 "at://did:example:EiAnKD8-jfdd0MDcZUjAbRgaThBrMxPTFOxcnfJhI7Ukaw/foo/bar",
                 "did:example:EiAnKD8-jfdd0MDcZUjAbRgaThBrMxPTFOxcnfJhI7Ukaw",
                 "/foo/bar",
+                [:],
                 nil,
-                nil, 
                 #line
             ),
             (
                 "at://did:example:EiAnKD8-jfdd0MDcZUjAbRgaThBrMxPTFOxcnfJhI7Ukaw?foo=bar",
                 "did:example:EiAnKD8-jfdd0MDcZUjAbRgaThBrMxPTFOxcnfJhI7Ukaw",
                 nil,
-                "foo=bar",
+                ["foo": "bar"],
                 nil, 
                 #line
             ),
@@ -82,31 +83,31 @@ final class ATURITests: XCTestCase {
                 "at://did:example:EiAnKD8-jfdd0MDcZUjAbRgaThBrMxPTFOxcnfJhI7Ukaw?foo=bar&baz=buux",
                 "did:example:EiAnKD8-jfdd0MDcZUjAbRgaThBrMxPTFOxcnfJhI7Ukaw",
                 nil,
-                "foo=bar&baz=buux",
-                nil, 
+                ["foo": "bar", "baz": "buux"],
+                nil,
                 #line
             ),
             (
                 "at://did:example:EiAnKD8-jfdd0MDcZUjAbRgaThBrMxPTFOxcnfJhI7Ukaw/?foo=bar",
                 "did:example:EiAnKD8-jfdd0MDcZUjAbRgaThBrMxPTFOxcnfJhI7Ukaw",
                 "/",
-                "foo=bar",
-                nil, 
+                ["foo": "bar"],
+                nil,
                 #line
             ),
             (
                 "at://did:example:EiAnKD8-jfdd0MDcZUjAbRgaThBrMxPTFOxcnfJhI7Ukaw/foo?foo=bar",
                 "did:example:EiAnKD8-jfdd0MDcZUjAbRgaThBrMxPTFOxcnfJhI7Ukaw",
                 "/foo",
-                "foo=bar",
-                nil, 
+                ["foo": "bar"],
+                nil,
                 #line
             ),
             (
                 "at://did:example:EiAnKD8-jfdd0MDcZUjAbRgaThBrMxPTFOxcnfJhI7Ukaw/foo/?foo=bar",
                 "did:example:EiAnKD8-jfdd0MDcZUjAbRgaThBrMxPTFOxcnfJhI7Ukaw",
                 "/foo/",
-                "foo=bar",
+                ["foo": "bar"],
                 nil, 
                 #line
             ),
@@ -114,163 +115,163 @@ final class ATURITests: XCTestCase {
                 "at://did:example:EiAnKD8-jfdd0MDcZUjAbRgaThBrMxPTFOxcnfJhI7Ukaw#hash",
                 "did:example:EiAnKD8-jfdd0MDcZUjAbRgaThBrMxPTFOxcnfJhI7Ukaw",
                 nil,
-                nil,
-                "#hash", 
+                [:],
+                "#hash",
                 #line
             ),
             (
                 "at://did:example:EiAnKD8-jfdd0MDcZUjAbRgaThBrMxPTFOxcnfJhI7Ukaw/#hash",
                 "did:example:EiAnKD8-jfdd0MDcZUjAbRgaThBrMxPTFOxcnfJhI7Ukaw",
                 "/",
-                nil,
-                "#hash", 
+                [:],
+                "#hash",
                 #line
             ),
             (
                 "at://did:example:EiAnKD8-jfdd0MDcZUjAbRgaThBrMxPTFOxcnfJhI7Ukaw/foo#hash",
                 "did:example:EiAnKD8-jfdd0MDcZUjAbRgaThBrMxPTFOxcnfJhI7Ukaw",
                 "/foo",
-                nil,
-                "#hash", 
+                [:],
+                "#hash",
                 #line
             ),
             (
                 "at://did:example:EiAnKD8-jfdd0MDcZUjAbRgaThBrMxPTFOxcnfJhI7Ukaw/foo/#hash",
                 "did:example:EiAnKD8-jfdd0MDcZUjAbRgaThBrMxPTFOxcnfJhI7Ukaw",
                 "/foo/",
-                nil,
-                "#hash", 
+                [:],
+                "#hash",
                 #line
             ),
             (
                 "at://did:example:EiAnKD8-jfdd0MDcZUjAbRgaThBrMxPTFOxcnfJhI7Ukaw?foo=bar#hash",
                 "did:example:EiAnKD8-jfdd0MDcZUjAbRgaThBrMxPTFOxcnfJhI7Ukaw",
                 nil,
-                "foo=bar",
-                "#hash", 
+                ["foo": "bar"],
+                "#hash",
                 #line
             ),
 
-            ("did:web:localhost%3A1234", "did:web:localhost%3A1234", nil, nil, nil, #line),
-            ("at://did:web:localhost%3A1234", "did:web:localhost%3A1234", nil, nil, nil, #line),
+            ("did:web:localhost%3A1234", "did:web:localhost%3A1234", nil, [:], nil, #line),
+            ("at://did:web:localhost%3A1234", "did:web:localhost%3A1234", nil, [:], nil, #line),
             (
                 "at://did:web:localhost%3A1234/",
                 "did:web:localhost%3A1234",
                 "/",
+                [:],
                 nil,
-                nil, 
                 #line
             ),
             (
                 "at://did:web:localhost%3A1234/foo",
                 "did:web:localhost%3A1234",
                 "/foo",
+                [:],
                 nil,
-                nil, 
                 #line
             ),
             (
                 "at://did:web:localhost%3A1234/foo/",
                 "did:web:localhost%3A1234",
                 "/foo/",
+                [:],
                 nil,
-                nil, 
                 #line
             ),
             (
                 "at://did:web:localhost%3A1234/foo/bar",
                 "did:web:localhost%3A1234",
                 "/foo/bar",
+                [:],
                 nil,
-                nil, 
                 #line
             ),
             (
                 "at://did:web:localhost%3A1234?foo=bar",
                 "did:web:localhost%3A1234",
                 nil,
-                "foo=bar",
-                nil, 
+                ["foo": "bar"],
+                nil,
                 #line
             ),
             (
                 "at://did:web:localhost%3A1234?foo=bar&baz=buux",
                 "did:web:localhost%3A1234",
                 nil,
-                "foo=bar&baz=buux",
-                nil, 
+                ["foo": "bar", "baz": "buux"],
+                nil,
                 #line
             ),
             (
                 "at://did:web:localhost%3A1234/?foo=bar",
                 "did:web:localhost%3A1234",
                 "/",
-                "foo=bar",
-                nil, 
+                ["foo": "bar"],
+                nil,
                 #line
             ),
             (
                 "at://did:web:localhost%3A1234/foo?foo=bar",
                 "did:web:localhost%3A1234",
                 "/foo",
-                "foo=bar",
-                nil, 
+                ["foo": "bar"],
+                nil,
                 #line
             ),
             (
                 "at://did:web:localhost%3A1234/foo/?foo=bar",
                 "did:web:localhost%3A1234",
                 "/foo/",
-                "foo=bar",
-                nil, 
+                ["foo": "bar"],
+                nil,
                 #line
             ),
             (
                 "at://did:web:localhost%3A1234#hash",
                 "did:web:localhost%3A1234",
                 nil,
-                nil,
-                "#hash", 
+                [:],
+                "#hash",
                 #line
             ),
             (
                 "at://did:web:localhost%3A1234/#hash",
                 "did:web:localhost%3A1234",
                 "/",
-                nil,
-                "#hash", 
+                [:],
+                "#hash",
                 #line
             ),
             (
                 "at://did:web:localhost%3A1234/foo#hash",
                 "did:web:localhost%3A1234",
                 "/foo",
-                nil,
-                "#hash", 
+                [:],
+                "#hash",
                 #line
             ),
             (
                 "at://did:web:localhost%3A1234/foo/#hash",
                 "did:web:localhost%3A1234",
                 "/foo/",
-                nil,
-                "#hash", 
+                [:],
+                "#hash",
                 #line
             ),
             (
                 "at://did:web:localhost%3A1234?foo=bar#hash",
                 "did:web:localhost%3A1234",
                 nil,
-                "foo=bar",
-                "#hash", 
+                ["foo": "bar"],
+                "#hash",
                 #line
             ),
             (
                 "at://4513echo.bsky.social/app.bsky.feed.post/3jsrpdyf6ss23",
                 "4513echo.bsky.social",
                 "/app.bsky.feed.post/3jsrpdyf6ss23",
+                [:],
                 nil,
-                nil, 
                 #line
             ),
         ]
@@ -299,5 +300,36 @@ final class ATURITests: XCTestCase {
             XCTAssertEqual(uri.collection, collection, line: line)
             XCTAssertEqual(uri.rkey, rkey, line: line)
         }
+    }
+
+    // https://github.com/bluesky-social/atproto/blob/0533fab68ea32df4e00948ddfc2422c6f900223a/packages/syntax/tests/aturi.test.ts#L276
+    func testModification() throws {
+        var uri = try XCTUnwrap(ATURI(string: "at://foo.com"))
+        XCTAssertEqual(uri.toString(), "at://foo.com/")
+
+        uri.host = "bar.com"
+        XCTAssertEqual(uri.toString(), "at://bar.com/")
+        uri.host = "did:web:localhost%3A1234"
+        XCTAssertEqual(uri.toString(), "at://did:web:localhost%3A1234/")
+        uri.host = "foo.com"
+
+        uri.path = "/"
+        XCTAssertEqual(uri.toString(), "at://foo.com/")
+        uri.path = "/foo"
+        XCTAssertEqual(uri.toString(), "at://foo.com/foo")
+        uri.path = "foo"
+        XCTAssertEqual(uri.toString(), "at://foo.com/foo")
+
+        // TODO: Support modifying collection & rkey
+
+        uri.query = ["foo": "bar"]
+        XCTAssertEqual(uri.toString(), "at://foo.com/foo?foo=bar")
+        uri.query["baz"] = "buux"
+        XCTAssertEqual(uri.toString(), "at://foo.com/foo?foo=bar&baz=buux")
+
+        uri.hash = "#hash"
+        XCTAssertEqual(uri.toString(), "at://foo.com/foo?foo=bar&baz=buux#hash")
+        uri.hash = "hash"
+        XCTAssertEqual(uri.toString(), "at://foo.com/foo?foo=bar&baz=buux#hash")
     }
 }

--- a/Tests/ATProtoCoreTests/Entities/ATURITests.swift
+++ b/Tests/ATProtoCoreTests/Entities/ATURITests.swift
@@ -332,4 +332,24 @@ final class ATURITests: XCTestCase {
         uri.hash = "hash"
         XCTAssertEqual(uri.toString(), "at://foo.com/foo?foo=bar&baz=buux#hash")
     }
+
+    func testEncoding() throws {
+        let uri = try XCTUnwrap(ATURI(string: "at://did:A:B/collection/rkey?foo=bar#hash"))
+
+        let encoder = JSONEncoder()
+        XCTAssertEqual(
+            String(data: try encoder.encode(uri), encoding: .utf8),
+            #""at:\/\/did:A:B\/collection\/rkey?foo=bar#hash""#
+        )
+    }
+
+    func testDecoding() throws {
+        let uri = try XCTUnwrap(ATURI(string: "at://did:A:B/collection/rkey?foo=bar#hash"))
+
+        let decoder = JSONDecoder()
+        XCTAssertEqual(
+            try decoder.decode(ATURI.self, from: #""at:\/\/did:A:B\/collection\/rkey?foo=bar#hash""#.data(using: .utf8)!),
+            uri
+        )
+    }
 }

--- a/Tests/ATProtoCoreTests/Entities/ATURITests.swift
+++ b/Tests/ATProtoCoreTests/Entities/ATURITests.swift
@@ -4,7 +4,7 @@ import XCTest
 
 final class ATURITests: XCTestCase {
     // https://github.com/bluesky-social/atproto/blob/0533fab68ea32df4e00948ddfc2422c6f900223a/packages/syntax/tests/aturi.test.ts#L4
-    func testInit() throws {
+    func testParsing() throws {
         let cases: [(String, String, String?, String?, String?, UInt)] = [
             ("foo.com", "foo.com", nil, nil, nil, #line),
             ("at://foo.com", "foo.com", nil, nil, nil, #line),
@@ -282,6 +282,22 @@ final class ATURITests: XCTestCase {
             XCTAssertEqual(uri.path, path, line: line)
             XCTAssertEqual(uri.query, query, line: line)
             XCTAssertEqual(uri.hash, hash, line: line)
+        }
+    }
+
+    // https://github.com/bluesky-social/atproto/blob/0533fab68ea32df4e00948ddfc2422c6f900223a/packages/syntax/tests/aturi.test.ts#L258
+    func testATProtoSpecificParsing() throws {
+        let cases: [(String, String?, String?, UInt)] = [
+            ("at://foo.com", nil, nil, #line),
+            ("at://foo.com/com.example.foo", "com.example.foo", nil, #line),
+            ("at://foo.com/com.example.foo/123", "com.example.foo", "123", #line),
+        ]
+
+        for (input, collection, rkey, line) in cases {
+            let uri = try XCTUnwrap(ATURI(string: input), line: line)
+
+            XCTAssertEqual(uri.collection, collection, line: line)
+            XCTAssertEqual(uri.rkey, rkey, line: line)
         }
     }
 }


### PR DESCRIPTION
From iOS 17, `URL` can't accept AT URI format string because it is invalid for RFC 3986.

https://developer.apple.com/documentation/foundation/url/3126806-init
> Important
>
> For apps linked on or after iOS 17 and aligned OS versions, URL parsing has updated from the obsolete RFC 1738/1808 parsing to the same RFC 3986 parsing as URLComponents. This unifies the parsing behaviors of the URL and URLComponents APIs. Now, URL automatically percent- and IDNA-encodes invalid characters to help create a valid URL.

This changes cause decoding failure on `at-uri` format string into `URL`. To avoid it, this PR introduces new struct `ATURI` which represents AT URI value.

Scheme: https://atproto.com/specs/at-uri-scheme