### PR TITLE
Adds submodule by HTTP instead of git

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "atproto"]
+	path = atproto
+	url = https://github.com/bluesky-social/atproto.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "atproto"]
-	path = atproto
-	url = git@github.com:bluesky-social/atproto.git


### PR DESCRIPTION
The build results of Swift Package Index indicate failure due to following error.

```
Please make sure you have the correct access rights
and the repository exists.
fatal: clone of 'git@github.com:bluesky-social/atproto.git' into submodule path '/Users/builder/builds/TDmZkXJm/1/finestructure/swiftpackageindex-builder/spi-builder-workspace/atproto' failed
Failed to clone 'atproto'. Retry scheduled
Cloning into '/Users/builder/builds/TDmZkXJm/1/finestructure/swiftpackageindex-builder/spi-builder-workspace/atproto'...
git@github.com: Permission denied (publickey).
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
fatal: clone of 'git@github.com:bluesky-social/atproto.git' into submodule path '/Users/builder/builds/TDmZkXJm/1/finestructure/swiftpackageindex-builder/spi-builder-workspace/atproto' failed
Failed to clone 'atproto' a second time, aborting
FAILURE checkout https://github.com/andooown/swift-atproto.git at 0.0.4
```
https://swiftpackageindex.com/builds/1E4AB39F-1E10-4F3B-9341-17AB87B52C60

It was probably caused by submodule which is added with `git@` scheme. So this PR re-adds submodule with `https` scheme.