### PR TITLE
Swift 5.9

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        swift-version: ["5.8"]
+        swift-version: ["5.9"]
     steps:
       - uses: swift-actions/setup-swift@v1
         with:
@@ -30,7 +30,7 @@ jobs:
         # masos-latest is disabled due to unknown error
         # i.e. https://github.com/andooown/swift-atproto/actions/runs/5891991845/job/15980295242
         os: [ubuntu-latest]
-        swift-version: ["5.8"]
+        swift-version: ["5.9"]
     steps:
       - uses: swift-actions/setup-swift@v1
         with:

--- a/Package.resolved
+++ b/Package.resolved
@@ -10,6 +10,15 @@
       }
     },
     {
+      "identity" : "swift-collections",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-collections.git",
+      "state" : {
+        "revision" : "a902f1823a7ff3c9ab2fba0f992396b948eda307",
+        "version" : "1.0.5"
+      }
+    },
+    {
       "identity" : "swift-parsing",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-parsing.git",

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.8
+// swift-tools-version: 5.9
 
 import PackageDescription
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@ Swift package that provides a AT Protocol libraries.
 
 🚧 This package is under development. 🚧
 
+## Requirements
+- Swift 5.9 or later
+
 ## Overview
 swift-atproto includes the following libraries.
 


### PR DESCRIPTION
To use Swift Macro, bump up the required Swift version to 5.9.